### PR TITLE
insert javascript after closing tag </title>

### DIFF
--- a/src/CookieAcceptBanner.php
+++ b/src/CookieAcceptBanner.php
@@ -28,8 +28,8 @@ class CookieAcceptBanner
             if ($api_key !== null) {
                 $html = sprintf(self::JS_STRING, $api_key);
                 $strBuffer = str_replace(
-                    '<head>',
-                    "<head>\n$html",
+                    '</title>',
+                    "</title>\n$html",
                     $strBuffer
                 );
             }


### PR DESCRIPTION
 We had some trouble, because the cookiebot script is inserted as first tag after `<head>`.

In our `fe_page` we set `<meta http-equiv="X-UA-Compatible" content="IE=11,chrome=1">` as second meta tag in `<head>` to tell the Microsoft Internet Explorer it hast to use the IE 11 environment.

If cookiebot script is inserted as first tag, the `X-UA-Compatible` didn't work anymore.
The closing tag `</title>` seemed to be the best alternative for us or do you know a better solution? 