### PR TITLE
Add support for culture

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ Please also read the [support instructions](https://support.cookiebot.com/hc/en-
 
 From Contao 4.8 onwards, the new page caching mechanism treats cookies
 differently than older Contao versions. For caching to work in the desired way,
-the Cookiebot cookie `CookieConsent` needs to be included in a global whitelist
+the Cookiebot cookie `CookieConsent` needs to be included in a global allow list
 for that environment. Manual action is required.  
-For details, see [COOKIE_WHITELIST in the Developer Documentation](https://docs.contao.org/dev/reference/config/#environment-variables-for-the-contao-managed-edition).
+For details, see [COOKIE_ALLOW_LIST in the Developer Documentation](https://docs.contao.org/dev/reference/config/#cookie-allow-list).
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ cookie blocking in the page settings. Please read the [implementation guide of C
 on how to manually mark cookie setting scripts and correctly implement
 Cookiebot on your website.
 
+If you want to set a fixed language, you can configure a Cookiebot culture (two-letter or three-letter code, e.g. `en`) in the page settings.
+Please also read the [support instructions](https://support.cookiebot.com/hc/en-us/articles/360003793394-How-to-set-the-language-of-the-consent-banner-).
+
 ### Caching in Contao >= 4.8
 
 From Contao 4.8 onwards, the new page caching mechanism treats cookies

--- a/src/CookieAcceptBanner.php
+++ b/src/CookieAcceptBanner.php
@@ -18,7 +18,7 @@ use Contao\PageModel;
  */
 class CookieAcceptBanner
 {
-    const JS_STRING = '<script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="%s" type="text/javascript" %s></script>';
+    const JS_STRING = '<script id="Cookiebot" src="https://consent.cookiebot.com/uc.js" data-cbid="%s" type="text/javascript" %s%s></script>';
 
     public function insertJavascriptIntoFullPage($strBuffer, $strTemplate)
     {
@@ -34,7 +34,11 @@ class CookieAcceptBanner
                 if ((int)$objRootPage->cookiebot_blockingmode_auto === 1) {
                     $blockingmode = 'data-blockingmode="auto"';
                 }
-                $html = sprintf(self::JS_STRING, $api_key, $blockingmode);
+                $culture = '';
+                if (!empty($objRootPage->cookiebot_culture)) {
+                    $culture = ' data-culture="'.$objRootPage->cookiebot_culture.'"';
+                }
+                $html = sprintf(self::JS_STRING, $api_key, $blockingmode, $culture);
                 $strBuffer = str_replace(
                     '</title>',
                     "</title>\n$html",

--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
 
 $GLOBALS['TL_DCA']['tl_page']['palettes']['__selector__'][] = 'cookiebot_active';
-$GLOBALS['TL_DCA']['tl_page']['subpalettes']['cookiebot_active'] = 'cookiebot_api_key,cookiebot_show_banner,cookiebot_blockingmode_auto';
+$GLOBALS['TL_DCA']['tl_page']['subpalettes']['cookiebot_active'] = 'cookiebot_api_key,cookiebot_show_banner,cookiebot_blockingmode_auto,cookiebot_culture';
 
 $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebot_active'] = array(
     'label' => &$GLOBALS['TL_LANG']['tl_page']['cookiebot_active'],
@@ -45,6 +45,14 @@ $GLOBALS['TL_DCA']['tl_page']['fields']['cookiebot_blockingmode_auto'] = array(
     'inputType' => 'checkbox',
     'eval' => array('tl_class' => 'w50 m12'),
     'sql' => "char(1) NOT NULL default '1'"
+);
+
+$GLOBALS['TL_DCA']['tl_page']['fields']['cookiebot_culture'] = array(
+    'label' => &$GLOBALS['TL_LANG']['tl_page']['cookiebot_culture'],
+    'exclude' => true,
+    'inputType' => 'text',
+    'eval' => array('tl_class' => 'w50', 'maxlength' => 3),
+    'sql' => "char(3) NOT NULL default ''"
 );
 
 if (isset($GLOBALS['TL_DCA']['tl_page']['palettes']['rootfallback'])) {

--- a/src/Resources/contao/languages/de/tl_page.php
+++ b/src/Resources/contao/languages/de/tl_page.php
@@ -29,3 +29,7 @@ $GLOBALS['TL_LANG']['tl_page']['cookiebot_blockingmode_auto'] = [
     'Automatische Cookie-Blockierung',
     'Aktiviert die automatische Cookie-Blockierung. Achtung: Wenn deaktiviert, müssen Cookies manuell blockiert werden!',
 ];
+$GLOBALS['TL_LANG']['tl_page']['cookiebot_culture'] = [
+    'Sprache der Cookiebot-Leiste',
+    'Setzt die Sprache der Cookiebot-Leiste optional auf eine gepflegte Sprache von Cookiebot (z.B. de).',
+];

--- a/src/Resources/contao/languages/en/tl_page.php
+++ b/src/Resources/contao/languages/en/tl_page.php
@@ -29,3 +29,7 @@ $GLOBALS['TL_LANG']['tl_page']['cookiebot_blockingmode_auto'] = [
     'Automatic cookie blocking',
     'This enables automatic cookie blocking. Attention: If disabled, all cookies must be blocked manually!',
 ];
+$GLOBALS['TL_LANG']['tl_page']['cookiebot_culture'] = [
+    'Language of the Cookiebot bar',
+    'Optionally sets the language of the Cookiebot bar to a maintained language of Cookiebot (e.g. en).',
+];


### PR DESCRIPTION
Add support to optionally set the culture - see: https://support.cookiebot.com/hc/en-us/articles/360003793394-How-to-set-the-language-of-the-consent-banner-


EDIT: I also update the link to the dev docs for the cookie allow list!